### PR TITLE
Add support for syndication

### DIFF
--- a/ckanext/agls/ckan_dataset.json
+++ b/ckanext/agls/ckan_dataset.json
@@ -23,7 +23,9 @@
       "label": "Description",
       "display_property": "dc:description",
       "form_snippet": "markdown.html",
-      "form_placeholder": "eg. Some useful notes about the data"
+      "form_placeholder": "eg. Some useful notes about the data",
+      "required": true,
+      "validators": "scheming_required"
     },
     {
       "field_name": "tag_string",
@@ -173,6 +175,16 @@
       "preset": "field_of_research",
       "output_validators": "custom_output_validator",
       "help_text": "The Australian and New Zealand Standard Research Classification (ANZSRC), 2008 defined field or fields of research relevant to the dataset."
+    },
+    {
+      "field_name": "syndicated_id",
+      "form_snippet": "hidden.html",
+      "initial_value": "null"
+    },
+    {
+      "field_name": "syndicate",
+      "form_snippet": "hidden.html",
+      "initial_value": "true"
     }
   ],
   "resource_fields": [

--- a/ckanext/agls/templates/scheming/form_snippets/hidden.html
+++ b/ckanext/agls/templates/scheming/form_snippets/hidden.html
@@ -1,1 +1,1 @@
-<input type="hidden" id="{{ field.field_name }}" name="{{ field.field_name }}" value="{{ data[field.field_name] }}">
+<input type="hidden" id="{{ field.field_name }}" name="{{ field.field_name }}" value="{{ data[field.field_name] or field.initial_value }}">


### PR DESCRIPTION
Several changes to support the portal being a ckanext-syndication source:
1. The Description field is mandatory
2. Adds the syndicated_id field to the schema
3. Adds the syndicate field to the field to the schema as the default syndication flag and sets it to true, i.e., syndicate all datasets